### PR TITLE
Fix `Open proof view` command not focusing the right proofview

### DIFF
--- a/client/src/HtmlCoqView.ts
+++ b/client/src/HtmlCoqView.ts
@@ -188,6 +188,8 @@ export class HtmlCoqView implements view.CoqView {
         this.handleClientMessage(message)
       );
       await this.updateSettings();
+    } else {
+      this.panel.reveal(undefined, true);
     }
   }
 


### PR DESCRIPTION
The `Open proof view` command does not focus the correct proofview if more than one proofview is open or if the tab was moved to another column.